### PR TITLE
(3-6-3) add two training widgets

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,7 @@ class MyApp extends StatelessWidget {
         // is not restarted.
         primarySwatch: Colors.blue,
       ),
-      home: MyHomePage(title: 'Flutter Demo Home Page'),
+      home: MySecondWidget(),
     );
   }
 }
@@ -108,6 +108,39 @@ class _MyHomePageState extends State<MyHomePage> {
         tooltip: 'Increment',
         child: Icon(Icons.add),
       ), // This trailing comma makes auto-formatting nicer for build methods.
+    );
+  }
+}
+
+class MyFirstWidget extends StatelessWidget {
+  int count = 0;
+  @override
+  Widget build(BuildContext context) {
+    count++;
+    print(count);
+    return Container(
+      child: Center(
+        child: Text('Hello'),
+      ),
+    );
+  }
+}
+
+class MySecondWidget extends StatefulWidget {
+  @override
+  _MySecondWidgetState createState() => _MySecondWidgetState();
+}
+
+class _MySecondWidgetState extends State<MySecondWidget> {
+  int count = 0;
+  @override
+  Widget build(BuildContext context) {
+    count++;
+    print(count);
+    return Container(
+      child: Center(
+        child: Text('Hello'),
+      ),
     );
   }
 }


### PR DESCRIPTION
в случае stateless виджета значение счетчика после hot reload не меняется (т.е. 1) - он рисуется 1 раз("The build method of a stateless widget is typically only called in three situations: the first time the widget is inserted in the tree, when the widget's parent changes its configuration, and when an InheritedWidget it depends on changes." - дока)

В Stateful виджете счетчик увеличивается.

Кроме того, конкретно "Hot reload loads code changes into the VM and re-builds the widget tree, preserving the app state" - то есть как раз для Stateful  состояние и сохранится как есть.